### PR TITLE
docs: remove duplicate 'directives' from example

### DIFF
--- a/modules/angular2/src/common/forms/directives/ng_control_group.ts
+++ b/modules/angular2/src/common/forms/directives/ng_control_group.ts
@@ -52,8 +52,7 @@ const controlGroupProvider =
  *         <pre>{{valueOf(f)}}</pre>
  *       </form>
  *     </div>
- *   `,
- *   directives: [FORM_DIRECTIVES]
+ *   `
  * })
  * export class App {
  *   valueOf(cg: NgControlGroup): string {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
  docs update, removed duplicate 'directives' from ng_control_group.ts
